### PR TITLE
Add agent rules for makefile execution

### DIFF
--- a/.agents/rules/makefile-targets.md
+++ b/.agents/rules/makefile-targets.md
@@ -1,0 +1,19 @@
+---
+trigger: glob
+description: Highlights the most common and important workflow targets for the OKD makefile.
+globs: "okd/makefile"
+---
+
+# Important Makefile Targets
+
+When working with the OKD makefile, the most common workflows that will be run are:
+
+- `make create-lb`
+- `make update-dns`
+- `make build`
+- `make clean`
+- `make use-kubeconfig`
+- `make copy-iso`
+- `make start-vms`
+
+These are considered the really important targets for the makefile.

--- a/.agents/rules/use-makefile.md
+++ b/.agents/rules/use-makefile.md
@@ -1,0 +1,6 @@
+---
+trigger: always_on
+description: Rule enforcing that all bash scripts and ansible playbooks must be run through the Makefile.
+---
+
+Do not run bash scripts directly and do not run ansible playbooks via the ansible cli directly. Everything should be done through the makefile (e.g., `okd/makefile`).


### PR DESCRIPTION
## Description

This pull request introduces agent rules to enforce the use of the makefile for executing scripts and playbooks. It ensures all operations go through the defined targets rather than being run directly, maintaining consistency and safety in how tasks are executed.

---

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Infrastructure change
- [ ] Refactor / cleanup
- [x] Documentation update
- [ ] CI/CD pipeline change
- [ ] Dependency update

---

## Changes Made

- Established agent instructions prohibiting direct execution of bash scripts and Ansible playbooks.
- Defined guidelines to exclusively use makefile targets for cluster operations and setups.

---

## Testing

- [x] Tested in **dev** environment

---

## Checklist

- [x] My changes follow the coding conventions and style of this project
- [x] I have updated relevant documentation
- [x] I have not committed any secrets or sensitive values
- [x] I have reviewed my own diff before requesting review

---

## Screenshots / Logs

N/A